### PR TITLE
Final Exercise(Intermediate Python) download link fix

### DIFF
--- a/website/content/03-intermediate-python/80-web-frameworks/final-exercise.md
+++ b/website/content/03-intermediate-python/80-web-frameworks/final-exercise.md
@@ -28,7 +28,7 @@ Let's review what we learned over the last two days and put it all together.
 
 For our final exercise today, we're going to build on yesterday's final exercise, where we wrote a program to query the GitHub API for a list of repos for certain programming languages, sorted by number of stars. We'll be turning yesterday's exercise into a Flask webapp. Flask is a simple and popular framework for creating basic web apps in Python.
 
-First, create a new folder for this exercise, called `day_two_final`. You'll need two folders of static content - CSS and HTML files - to make this work. You can [download them here](http://localhost:1313/code/day_two_final_exercise/static_files.zip). Unzip your `static_files.zip` file and copy your `static` and `template` folders to your `day_two_final` folder.
+First, create a new folder for this exercise, called `day_two_final`. You'll need two folders of static content - CSS and HTML files - to make this work. You can [download them here](https://www.learnpython.dev/code/day_two_final_exercise/static_files.zip). Unzip your `static_files.zip` file and copy your `static` and `template` folders to your `day_two_final` folder.
 
 Next, create a folder called `repos`. This is where we'll create our custom module. Inside this folder we'll create three files: `exceptions.py`, `models.py`, and `api.py`.
 


### PR DESCRIPTION
Static assets download link was pointing to localhost. Changed it to `https://www.learnpython.dev`.  
Not sure if this is correct thing to do but it fixes the download link. I see **baseurl** setup in `config.toml`. 
Can that be used in this `.md` file to point to correct assets? 