### PR TITLE
Add language label only if class attribute exists

### DIFF
--- a/website/themes/nnja-theme-learn/static/js/learn.js
+++ b/website/themes/nnja-theme-learn/static/js/learn.js
@@ -8,7 +8,10 @@ $("pre code").each(function (i, e) {
     var code = $(e);
     var pre = code.parent();
 
-    var language = code.attr('class').replace('language-', '');
+    var className = code.attr('class');
+    if(!className) return;
+
+    var language = className.replace('language-', '');
     var text_block = pre.text();
 
     is_python_repl = text_block.includes(">>> ");


### PR DESCRIPTION
The app breaks if any of the `$('pre code')` tags doesn't have a class attribute. For example [https://www.learnpython.dev/02-introduction-to-python/060-functions/30-function-arguments/](https://www.learnpython.dev/02-introduction-to-python/060-functions/30-function-arguments/)

I change the code to be more forgiving so that it will not break which fixes #80.

